### PR TITLE
fix: 국내 뉴스 시황 제목 전처리

### DIFF
--- a/app/crawlers/fetch_kosdaq_news_now.py
+++ b/app/crawlers/fetch_kosdaq_news_now.py
@@ -5,13 +5,20 @@ kosdaq_crawler.py의 스케줄과 관계없이 지금 당장 실행합니다.
 이미 DB에 저장된 기사라도 최신 요약으로 덮어씁니다.
 
 실행 방법:
-    python -m app.crawlers.fetch_kosdaq_news_now
+    python -m app.crawlers.fetch_kosdaq_news_now
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
+import app.crawlers.kosdaq_crawler as _crawler
 from app.crawlers.kosdaq_crawler import run_job
 
+KST = timezone(timedelta(hours=9))
 
 if __name__ == "__main__":
-    run_job()
+    yesterday = datetime.now(KST) - timedelta(days=1)
+    with patch.object(_crawler, "datetime") as mock_dt:
+        mock_dt.now.return_value = yesterday
+        mock_dt.strptime = datetime.strptime
+        run_job()

--- a/app/crawlers/kosdaq_crawler.py
+++ b/app/crawlers/kosdaq_crawler.py
@@ -162,7 +162,7 @@ def fetch_today_articles() -> list:
 
         for item in items:
             article_id       = item.get("id", "")
-            title            = item.get("title", "").replace("[마감시황]", "").strip()
+            title            = item.get("title", "").replace("[마감시황]", "").replace("(마감시황)", "").strip()
             raw_html         = item.get("content", "")
             link             = item.get("link", "")
             release_date_str = item.get("releaseDate") or item.get("firstReleaseDate", "")


### PR DESCRIPTION
한국 시황 뉴스 제목에 '(마감시황 )' 제거하고 크롤링 